### PR TITLE
express (aka expressjs) template

### DIFF
--- a/bun-examples-all/package.json
+++ b/bun-examples-all/package.json
@@ -51,6 +51,10 @@
     "@bun-examples/websi": {
       "version": "0.1.18",
       "description": ""
+    },
+    "@bun-examples/express": {
+      "version": "0.0.1",
+      "description": ""
     }
   }
 }

--- a/express/app.js
+++ b/express/app.js
@@ -1,0 +1,32 @@
+import createError from 'http-errors';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import logger from 'morgan';
+import indexRouter from './routes/index';
+
+var app = express();
+
+app.use(logger('dev'));
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+
+app.use('/', indexRouter);
+
+// catch 404 and forward to error handler
+app.use(function(req, res, next) {
+  next(createError(404));
+});
+
+// error handler
+app.use(function(err, req, res, next) {
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error = req.app.get('env') === 'development' ? err : {};
+
+  // render the error page
+  res.status(err.status || 500);
+  res.render('error');
+});
+
+export default app;

--- a/express/bin/www.js
+++ b/express/bin/www.js
@@ -3,9 +3,6 @@
 /**
  * Module dependencies.
  */
-// var app = require('../app');
-// var debug = require('debug')('express:server');
-// var http = require('http');
 import app from '../app';
 import Bun from 'bun';
 
@@ -19,11 +16,9 @@ app.set('port', port);
 /**
  * Create HTTP server.
  */
-
-// var server = http.createServer(app);
 const server = Bun.serve({
   fetch: (req, res) => {
-    // https://stackoverflow.com/questions/73903453/does-node-fetch-support-request-forwarding
+    // cf.: https://stackoverflow.com/questions/73903453/does-node-fetch-support-request-forwarding
     res.pipe(req);
   },
   // Optional port number - the default value is 3000
@@ -38,7 +33,6 @@ app.listen(port);
 /**
  * Normalize a port into a number, string, or false.
  */
-
 function normalizePort(val) {
   var port = parseInt(val, 10);
 

--- a/express/bin/www.js
+++ b/express/bin/www.js
@@ -22,8 +22,9 @@ app.set('port', port);
 
 // var server = http.createServer(app);
 const server = Bun.serve({
-  fetch: (req, res, next) => {
-    next();
+  fetch: (req, res) => {
+    // https://stackoverflow.com/questions/73903453/does-node-fetch-support-request-forwarding
+    res.pipe(req);
   },
   // Optional port number - the default value is 3000
   port

--- a/express/bin/www.js
+++ b/express/bin/www.js
@@ -9,7 +9,6 @@ import Bun from 'bun';
 /**
  * Get port from environment and store in Express.
  */
-
 var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
@@ -18,13 +17,14 @@ app.set('port', port);
  */
 const server = Bun.serve({
   fetch: (req) => {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Response
+    // https://bun.sh/docs/ecosystem/express
     // https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static
     return Response.redirect(req.url);
   },
   // Optional port number - the default value is 3000
   port
 });
+
 /**
  * Listen on provided port, on all network interfaces.
  */

--- a/express/bin/www.js
+++ b/express/bin/www.js
@@ -17,9 +17,10 @@ app.set('port', port);
  * Create HTTP server.
  */
 const server = Bun.serve({
-  fetch: (req, res) => {
-    // cf.: https://stackoverflow.com/questions/73903453/does-node-fetch-support-request-forwarding
-    res.pipe(req);
+  fetch: (req) => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect_static
+    return Response.redirect(req.url);
   },
   // Optional port number - the default value is 3000
   port

--- a/express/bin/www.js
+++ b/express/bin/www.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+// var app = require('../app');
+// var debug = require('debug')('express:server');
+// var http = require('http');
+import app from '../app';
+import Bun from 'bun';
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+// var server = http.createServer(app);
+const server = Bun.serve({
+  fetch: (req, res, next) => {
+    next();
+  },
+  // Optional port number - the default value is 3000
+  port
+});
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+app.set('server', server);
+app.listen(port);
+
+/**
+ * Normalize a port into a number, string, or false.
+ */
+
+function normalizePort(val) {
+  var port = parseInt(val, 10);
+
+  if (isNaN(port)) {
+    // named pipe
+    return val;
+  }
+
+  if (port >= 0) {
+    // port number
+    return port;
+  }
+
+  return false;
+}

--- a/express/package.json
+++ b/express/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "express",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "bun ./bin/www.js"
+  },
+  "dependencies": {
+    "bun": "^0.6.7",
+    "bun-types": "^0.6.7",
+    "cookie-parser": "~1.4.4",
+    "debug": "~2.6.9",
+    "express": "^4.18.2",
+    "http-errors": "~1.6.3",
+    "jade": "~1.11.0",
+    "morgan": "~1.9.1"
+  },
+  "type": "module"
+}

--- a/express/package.json
+++ b/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "start": "bun ./bin/www.js"

--- a/express/routes/index.js
+++ b/express/routes/index.js
@@ -1,0 +1,11 @@
+// var express = require('express');
+import express from 'express';
+var router = express.Router();
+
+/* GET home page. */
+router.get('/*', function(req, res, next) {
+  res.send('Express');
+});
+
+// module.exports = router;
+export default router;

--- a/express/routes/index.js
+++ b/express/routes/index.js
@@ -3,7 +3,8 @@ var router = express.Router();
 
 /* GET home page. */
 router.get('/*', function(req, res, next) {
-  res.send('Express');
+  const message = `request.url: ${req.url}\n`;
+  res.send(message);
 });
 
 export default router;

--- a/express/routes/index.js
+++ b/express/routes/index.js
@@ -1,4 +1,3 @@
-// var express = require('express');
 import express from 'express';
 var router = express.Router();
 
@@ -7,5 +6,4 @@ router.get('/*', function(req, res, next) {
   res.send('Express');
 });
 
-// module.exports = router;
 export default router;


### PR DESCRIPTION
I created a template with ``bunx express-generator`` (the official one).
This template was adjusted to use the server created by ``Bun.serve``.
Furthermore, the ``.jade`` view-generation (of express itself) was removed.