### PR TITLE
fix(astro): template not being published to npm

### DIFF
--- a/astro/package.json
+++ b/astro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astro",
+  "name": "@bun-examples/astro",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
`publish.js` ignores templates if its `package.json`'s `name` property doesn't start with `@bun-examples`, this change adds `@bun-examples/` as the prefix to the astro template's name